### PR TITLE
Add anssi metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to This Project
+
+Thank you for your interest in this project. Please read this document
+carefully before considering any contributions.
+
+## Scope of Contributions
+
+This project only accepts contributions related to security maintenance. No
+other types of contributions are expected or will be accepted at this time.
+
+## Support Policy
+
+Thank you for understanding and respecting the limited scope of this project's
+contributions and support. In particular, there is no commitment regarding
+processing times.
+
+### Limited Support Scope
+
+- Support is provided exclusively to contributors working on security-related
+  improvements.
+- The project maintainers will only assist with issues directly related to your
+  security maintenance contributions.
+
+### No General Support
+
+- We do not offer general support for using or setting up the project.
+- Questions, feature requests, or issues unrelated to active security
+  maintenance contributions will not be addressed.
+
+## How to Contribute
+
+1. Ensure your contribution is strictly related to security maintenance.
+2. Fork the repository and create a new branch for your work.
+3. Submit a pull request with a clear description of your security-related
+   improvements.
+
+## Security Vulnerabilities
+
+If you discover a security vulnerability, please report it according to our
+security policy outlined in the [`SECURITY.md`](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Copyright (C) 2023
 
 **Contributors**: Adrian THILLARD, Emmanuel PROUFF
 
+<img src="https://www.sgdsn.gouv.fr/files/styles/ds_image_paragraphe/public/files/Notre_Organisation/logo_anssi.png" alt="ANSSI logo" width="30%">
+
+## French Cybersecurity Agency (ANSSI)
+
+[![badge_repo](https://img.shields.io/badge/ANSSI--FR-IPECC-white)](https://github.com/ANSSI-FR/template)
+[![category_badge_doctrinal](https://img.shields.io/badge/category-doctrinal-%23e9c7e7)](https://anssi-fr.github.io/README.en.html#project-categories)
+[![openess_badge_C](https://img.shields.io/badge/code.gouv.fr-published-orange)](https://documentation.ouvert.numerique.gouv.fr/les-parcours-de-documentation/ouvrir-un-projet-num%C3%A9rique/#niveau-ouverture)
+
+*This projet is managed by [ANSSI](https://cyber.gouv.fr/). To find out more, you can visit the [page](https://cyber.gouv.fr/enjeux-technologiques/open-source/) (in French) dedicated to ANSSI’s open-source strategy. You can also click on the badges above to learn more about their meaning.*
+
 ## Introduction
 
 IPECC is a hardware IP block performing the computation of scalar multiplication $[k]P$ over elliptic curves defined in short Weierstrass form on a finite field of charasteristic $p > 3$. IPECC has been developped mainly for SRAM-based FPGAs (both Xilinx and Intel-Altera) but it should also be usable as input to an ASIC flow without any kind of restriction.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please help us
+address it responsibly by following these steps:
+
+1. **Do not publicly disclose the vulnerability.**
+2. Contact us directly at
+   [opensource@ssi.gouv.fr](mailto:opensource@ssi.gouv.fr) with the following
+   details:
+   - A clear description of the issue.
+   - Steps to reproduce the vulnerability.
+   - Any potential impact or exploit scenarios.
+
+Thank you for helping us keep this project secure!


### PR DESCRIPTION
Hey team,

here's a PR to add some ANSSI metadata to the repository, following the publication of the ANSSI open source strategy.

The project category and the openness level can be adjusted, as well as the content of the SECURITY and CONTRIBUTING files, if you think other choices make more sense.